### PR TITLE
Replace cookie-based authentication with basic authentication, add inline help

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Kenny Levinsen
+Portions Copyright (c) 2019 David Romano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ Beware that v9fs, the 9P kernel support for Linux, has a few bugs. One is that i
 
 These issues are due to v9fs not getting much use as a "normal" 9P client, but let's change that!
 
-On MacOSX, you can use plan9port and 9pfuse. First install [FUSE for macOS](https://osxfuse.github.io/). Then install [plan9port](https://9fans.github.io/plan9port/). You can then use 9pfuse to mount. Beware, however, that stock 'ls' on MacOSX won't work to show the available directory files--you have to use '9 ls', '9 lc' etc.
+On MacOSX, there are two options:
+* You can use plan9port which provides 9pfuse. First install [FUSE for macOS](https://osxfuse.github.io/). Then install [plan9port](https://9fans.github.io/plan9port/). You can then use 9pfuse to mount. Beware, however, that stock 'ls' on MacOSX won't work to show the available directory files--you have to use '9 ls', '9 lc' etc.
 ```plain
 cd jirafs; go build; ./jirafs -pass -url=https://jira.example.com
 # then after entering credentials, open another terminal in the parent directory you want for accessing JIRA:
 9pfuse 'tcp!localhost!30000' my-jira; cd my-jira; 9 lc projects
 ```
+* You can use [Mac9P](https://github.com/kennylevinsen/mac9p). Follow the install instructions.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Beware that v9fs, the 9P kernel support for Linux, has a few bugs. One is that i
 
 These issues are due to v9fs not getting much use as a "normal" 9P client, but let's change that!
 
-On MacOSX, you can use plan9port and 9pfuse. First install [FUSE for macOS](https://osxfuse.github.io/). Then install [plan9port](https://9fans.github.io/plan9port/). You can then use 9pfuse to mount. Beware, however, that stock 'ls' on MacOSX won't work to show the avaiable directory files--you have to use '9 ls', '9 lc' etc.
+On MacOSX, you can use plan9port and 9pfuse. First install [FUSE for macOS](https://osxfuse.github.io/). Then install [plan9port](https://9fans.github.io/plan9port/). You can then use 9pfuse to mount. Beware, however, that stock 'ls' on MacOSX won't work to show the available directory files--you have to use '9 ls', '9 lc' etc.
 ```plain
 cd jirafs; go build; ./jirafs -pass -url=https://jira.example.com
 # then after entering credentials, open another terminal in the parent directory you want for accessing JIRA:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 jirafs is a 9P fileserver that presents JIRA as a filesystem. It tries to be feature-complete without getting in the way.
 
-jirafs supports both username/password login, and oauth 1.0 login to JIRA. Note that username/password logins expire at seemingly arbitrary intervals, so it may prove slightly unreliable.
+jirafs supports both username/password (basic authentication) login, and oauth 1.0 login to JIRA.
 
 ## OAuth
 
@@ -14,9 +14,9 @@ openssl rsa -pubout -in private_key.pem -out public_key.pem
 
 After setting this up, you will have to set up a generic application link in JIRA, entering arbitrary URL's (they don't matter), a consumer key and the public key generated above. Once done, starting jirafs with `-oath -ckey consumer_key -pkey private_key.pem` should work, requesting that you go through the OAuth verification step (note that -ckey is the literal key, not a path to a key file).
 
-## Username/password auth
+## Username/password (basic) auth
 
-Simply start jirafs with the `-pass` option. If you want to configure the automatic relogin, see the `-loginint` or `-alwayslogin` options.
+Simply start jirafs with the `-pass` option.
 
 ## Mounting jirafs
 
@@ -28,6 +28,13 @@ sudo mount -t 9p -o trans=tcp,port=30000,noextend,sync,dirsync,nosuid,tcp 127.0.
 Beware that v9fs, the 9P kernel support for Linux, has a few bugs. One is that it does not feed through the OTRUNC opening option properly, meaning that some "echo wee > file" becomes "echo wee >> file" instead. Another is that it does not handle large directory listings well, so keep maxlisting to about 100. The patches to fix these issues are on their way, but it will probably take a while before you'll get the update.
 
 These issues are due to v9fs not getting much use as a "normal" 9P client, but let's change that!
+
+On MacOSX, you can use plan9port and 9pfuse. First install [FUSE for macOS](https://osxfuse.github.io/). Then install [plan9port](https://9fans.github.io/plan9port/). You can then use 9pfuse to mount. Beware, however, that stock 'ls' on MacOSX won't work to show the avaiable directory files--you have to use '9 ls', '9 lc' etc.
+```plain
+cd jirafs; go build; ./jirafs -pass -url=https://jira.example.com
+# then after entering credentials, open another terminal in the parent directory you want for accessing JIRA:
+9pfuse 'tcp!localhost!30000' my-jira; cd my-jira; 9 lc projects
+```
 
 ## Disclaimer
 

--- a/TODO
+++ b/TODO
@@ -2,3 +2,4 @@
 * Return directory listing of saved queries by ordering in JQL
   * Support orderBy as control for each listing
 * Support startAt,total pagination control
+* ?Use https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/jira-rest-plugin.wadl in some way?

--- a/TODO
+++ b/TODO
@@ -1,0 +1,4 @@
+* Support saving of queries across mounts/unmounts, per username
+* Return directory listing of saved queries by ordering in JQL
+  * Support orderBy as control for each listing
+* Support startAt,total pagination control

--- a/client.go
+++ b/client.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-    "io"
-    "io/ioutil"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -18,8 +18,8 @@ import (
 type Client struct {
 	*http.Client
 
-	user, pass              string
-	jiraURL                 *url.URL
+	user, pass string
+	jiraURL    *url.URL
 	usingOAuth bool
 
 	maxlisting int
@@ -41,7 +41,7 @@ func (c *Client) RPC(method, path string, body, target interface{}) error {
 		return err
 	}
 
-    var b io.Reader
+	var b io.Reader
 	switch x := body.(type) {
 	case nil:
 	case []byte:
@@ -65,7 +65,7 @@ func (c *Client) RPC(method, path string, body, target interface{}) error {
 	req.Header.Set("X-Atlassian-Token", "nocheck")
 
 	if !c.usingOAuth {
-		req.SetBasicAuth(c.user, c.pass);
+		req.SetBasicAuth(c.user, c.pass)
 	}
 
 	resp, err := c.Client.Do(req)

--- a/client.go
+++ b/client.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io"
-	"io/ioutil"
+    "io"
+    "io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -20,8 +20,7 @@ type Client struct {
 
 	user, pass              string
 	jiraURL                 *url.URL
-	cookies                 []*http.Cookie
-	alwaysLogin, usingOAuth bool
+	usingOAuth bool
 
 	maxlisting int
 }
@@ -42,7 +41,7 @@ func (c *Client) RPC(method, path string, body, target interface{}) error {
 		return err
 	}
 
-	var b io.Reader
+    var b io.Reader
 	switch x := body.(type) {
 	case nil:
 	case []byte:
@@ -65,14 +64,8 @@ func (c *Client) RPC(method, path string, body, target interface{}) error {
 	}
 	req.Header.Set("X-Atlassian-Token", "nocheck")
 
-	if c.alwaysLogin && !c.usingOAuth {
-		if err := c.AcquireSessionCookie(c.user, c.pass); err != nil {
-			return err
-		}
-	}
-
-	for _, cookie := range c.cookies {
-		req.AddCookie(cookie)
+	if !c.usingOAuth {
+		req.SetBasicAuth(c.user, c.pass);
 	}
 
 	resp, err := c.Client.Do(req)
@@ -103,54 +96,6 @@ func (c *Client) RPC(method, path string, body, target interface{}) error {
 
 	return nil
 
-}
-
-func (c *Client) AcquireSessionCookie(username, password string) error {
-	url, err := c.jiraURL.Parse("/rest/auth/1/session")
-	if err != nil {
-		return err
-	}
-
-	body := struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
-	}{username, password}
-	b, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url.String(), bytes.NewReader(b))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.Client.Do(req)
-	if _, err := ioutil.ReadAll(resp.Body); err != nil {
-		return err
-	}
-	resp.Body.Close()
-	c.cookies = resp.Cookies()
-
-	if err != nil {
-		return fmt.Errorf("Auth at JIRA instance failed (HTTP(S) request). %s", err)
-	}
-	if resp != nil && resp.StatusCode != 200 {
-		return fmt.Errorf("Auth at JIRA instance failed (HTTP(S) request). Status code: %d", resp.StatusCode)
-	}
-
-	return nil
-}
-
-func (c *Client) login() error {
-	if c.usingOAuth {
-		return nil
-	}
-	if err := c.AcquireSessionCookie(c.user, c.pass); err != nil {
-		return fmt.Errorf("Could not authenticate to JIRA: %v\n", err)
-	}
-	return nil
 }
 
 func (c *Client) oauth(consumerKey, privateKeyFile string) error {

--- a/jira.go
+++ b/jira.go
@@ -205,7 +205,7 @@ type IssueView struct {
 
 	issueLock sync.Mutex
 	newIssue  bool
-	values    map[string]string
+	values	map[string]string
 }
 
 func (iw *IssueView) normalFiles() (files, dirs []string) {
@@ -259,7 +259,7 @@ func (iw *IssueView) newWalk(jc *Client, file string) (trees.File, error) {
 						Project: jira.Project{
 							Key: project,
 						},
-						Summary:     summary,
+						Summary:	 summary,
 						Description: description,
 					},
 				}
@@ -440,7 +440,7 @@ func (iw *IssueView) normalWalk(jc *Client, file string) (trees.File, error) {
 			jc,
 			&IssueWorklogView{issueNo: iw.issueNo})
 	case "raw":
-		b, err := json.MarshalIndent(issue, "", "   ")
+		b, err := json.MarshalIndent(issue, "", "	")
 		if err != nil {
 			return nil, err
 		}
@@ -624,9 +624,9 @@ func (iw *IssueView) List(jc *Client) ([]qp.Stat, error) {
 }
 
 type SearchView struct {
-	query      string
+	query	  string
 	resultLock sync.Mutex
-	results    []string
+	results	[]string
 }
 
 func (sw *SearchView) search(jc *Client) error {
@@ -760,7 +760,7 @@ func (pw *ProjectView) Walk(jc *Client, file string) (trees.File, error) {
 		if err != nil {
 			return nil, err
 		}
-		b, err := json.MarshalIndent(project, "", "   ")
+		b, err := json.MarshalIndent(project, "", "	")
 		if err != nil {
 			return nil, err
 		}
@@ -819,6 +819,72 @@ func (aiv *AllIssuesView) Walk(jc *Client, issueKey string) (trees.File, error) 
 
 	if issueKey == "new" {
 		iw.newIssue = true
+	} else if issueKey == "help" {
+		message := `new/: New is a folder that creates a new skeleton issue when entered. It only contains a minimal set of files necessary to create the issue. Once all fields have been filled out, writing "commit" to the ctl file will cause the issue to be created. The issue folder will change to be that of a created issue, with all files available. Read the "key" file to figure out what issue key your issue received.
+ABC-1/: A folder containing information for ticket '1' in project 'ABC'.
+ABC-1/comments/: A folder containing comments for the issue. Writing to the comment file creates a new comment. Writing to an existing comment changes it. This structure may change in the future.
+ABC-1/components: A list of components this issue applies to. Writable. Note that the component names are case sensitive, and must be match an existing component for the project.
+ABC-1/ctl: A command file. On a new issue, the only accepted command is "commit", which creates the issue with the provided parameters. For existing issues, the only accepted command is "delete". In the future, more commands may be made available for things that map poorly to files.
+ABC-1/links: Issue links in the form of "INWARD-ISSUE OUTWARD-ISSUE RELATIONSHIP", such as "ABC-1 ABC-2 Blocks". Writable.
+ABC-1/raw: The raw JSON issue object. Writable. Expects the written data to be JSON, and the write will be pushed as an issue update.
+ABC-1/status: When writing to the status file, jirafs will fetch the relevant workflow graph and trace the shortest path from the current status to the requested status, issuing the necessary transitions in order.
+ABC-1/transition: A list of currently possible transitions. Writing to the file executes the transition. See status for a more convenient way of changing issue status.
+
+For deeper structural representation under this hierarchy, cat 'structure'.
+`
+		sf := trees.NewSyntheticFile(issueKey, 0555, "jira", "jira")
+		sf.SetContent([]byte(message))
+		return sf, nil
+	} else if issueKey == "structure" {
+        message :=`new/
+	 ctl
+	 description
+	 project
+	 summary
+	 type
+  ABC-1/
+	 assignee
+	 comments/
+		1/
+			author
+			updated
+			created
+			comment
+		2/
+			...
+		...
+		comment
+	 components
+	 creator
+	 ctl
+	 description
+	 key
+	 labels
+	 links
+	 priority
+	 progress
+	 project
+	 raw
+	 reporter
+	 resolution
+	 status
+	 summary
+	 transition
+	 type
+	 worklog/
+		1/
+			author
+			started
+			time
+			comment
+		...
+  ABC-2/
+	 ...
+  ...
+`
+		sf := trees.NewSyntheticFile(issueKey, 0555, "jira", "jira")
+		sf.SetContent([]byte(message))
+		return sf, nil
 	} else {
 		s := strings.Split(strings.ToUpper(issueKey), "-")
 		if len(s) != 2 {
@@ -852,13 +918,15 @@ func (aiv *AllIssuesView) List(jc *Client) ([]qp.Stat, error) {
 		return nil, err
 	}
 
-	keys = append(keys, "new")
-	return StringsToStats(keys, 0555|qp.DMDIR, "jira", "jira"), nil
+	keys	= append(keys, "new")
+	issues := StringsToStats(keys, 0555|qp.DMDIR, "jira", "jira")
+	help	:= StringsToStats([]string{"help","structure"}, 055, "jira", "jira")
+	return append(issues, help...), nil
 }
 
 type JiraView struct {
 	searchLock sync.Mutex
-	searches   map[string]*SearchView
+	searches	map[string]*SearchView
 }
 
 func (jw *JiraView) Walk(jc *Client, file string) (trees.File, error) {
@@ -915,6 +983,88 @@ func (jw *JiraView) Walk(jc *Client, file string) (trees.File, error) {
 		return NewJiraDir(file, 0555|qp.DMDIR, "jira", "jira", jc, &AllProjectsView{})
 	case "issues":
 		return NewJiraDir(file, 0555|qp.DMDIR, "jira", "jira", jc, &AllIssuesView{})
+	case "structure":
+message := `
+/
+	ctl
+	projects/
+	  ABC/
+		 components
+		 issuetypes
+		 issues/
+			1/ # ABC-1
+				...
+			...
+
+	  DEF/
+		 ...
+	  ...
+	issues/
+	  new/
+		 ctl
+		 description
+		 project
+		 summary
+		 type
+	  ABC-1/
+		 assignee
+		 comments/
+			1/
+				author
+				updated
+				created
+				comment
+			2/
+				...
+			...
+			comment
+		 components
+		 creator
+		 ctl
+		 description
+		 key
+		 labels
+		 links
+		 priority
+		 progress
+		 project
+		 raw
+		 reporter
+		 resolution
+		 status
+		 summary
+		 transition
+		 type
+		 worklog/
+			1/
+				author
+				started
+				time
+				comment
+			...
+	  ABC-2/
+		 ...
+	  ...
+`
+		sf := trees.NewSyntheticFile(file, 0555, "jira", "jira")
+		sf.SetContent([]byte(message))
+		return sf, nil
+	case "help":
+		message := `ctl: A global control file. It supports the following commands:
+	* search search_name JQL
+		If successful, a folder named search_name will appear at the jirafs root. ls'ing in the folder updates the search. The search does not update when simply trying to access an issue in order to avoid significant performance issues.
+	* pass-login
+		Re-issue a username/password login using the initially provided credentials.
+	* set name val
+		Sets jirafs variables. Currently, max-listing is the only variable, which expects an integer.
+projects/: Directory listing of projects.
+issues/: Directory listing of issues
+
+For deeper structural representation, cat 'structure'
+`
+		sf := trees.NewSyntheticFile(file, 0555, "jira", "jira")
+		sf.SetContent([]byte(message))
+		return sf, nil
 	default:
 		search, exists := jw.searches[file]
 
@@ -940,13 +1090,14 @@ func (jw *JiraView) List(jc *Client) ([]qp.Stat, error) {
 
 	a := StringsToStats([]string{"projects", "issues"}, 0555|qp.DMDIR, "jira", "jira")
 	b := StringsToStats([]string{"ctl"}, 0777, "jira", "jira")
-	c := StringsToStats(strs, 0777|qp.DMDIR, "jira", "jira")
-	return append(append(a, b...), c...), nil
+	c := StringsToStats([]string{"help", "structure"}, 0555, "jira", "jira")
+	d := StringsToStats(strs, 0777|qp.DMDIR, "jira", "jira")
+	return append(append(append(a, b...), c...), d...), nil
 }
 
 func (jw *JiraView) Remove(jc *Client, file string) error {
 	switch file {
-	case "ctl", "projects", "issues":
+	case "ctl", "projects", "issues", "structure", "help":
 		return trees.ErrPermissionDenied
 	default:
 		jw.searchLock.Lock()

--- a/jira.go
+++ b/jira.go
@@ -205,7 +205,7 @@ type IssueView struct {
 
 	issueLock sync.Mutex
 	newIssue  bool
-	values	map[string]string
+	values    map[string]string
 }
 
 func (iw *IssueView) normalFiles() (files, dirs []string) {
@@ -259,7 +259,7 @@ func (iw *IssueView) newWalk(jc *Client, file string) (trees.File, error) {
 						Project: jira.Project{
 							Key: project,
 						},
-						Summary:	 summary,
+						Summary:     summary,
 						Description: description,
 					},
 				}
@@ -624,9 +624,9 @@ func (iw *IssueView) List(jc *Client) ([]qp.Stat, error) {
 }
 
 type SearchView struct {
-	query	  string
+	query      string
 	resultLock sync.Mutex
-	results	[]string
+	results    []string
 }
 
 func (sw *SearchView) search(jc *Client) error {
@@ -836,7 +836,7 @@ For deeper structural representation under this hierarchy, cat 'structure'.
 		sf.SetContent([]byte(message))
 		return sf, nil
 	} else if issueKey == "structure" {
-        message :=`new/
+		message := `new/
 	 ctl
 	 description
 	 project
@@ -918,15 +918,15 @@ func (aiv *AllIssuesView) List(jc *Client) ([]qp.Stat, error) {
 		return nil, err
 	}
 
-	keys	= append(keys, "new")
+	keys = append(keys, "new")
 	issues := StringsToStats(keys, 0555|qp.DMDIR, "jira", "jira")
-	help	:= StringsToStats([]string{"help","structure"}, 055, "jira", "jira")
+	help := StringsToStats([]string{"help", "structure"}, 055, "jira", "jira")
 	return append(issues, help...), nil
 }
 
 type JiraView struct {
 	searchLock sync.Mutex
-	searches	map[string]*SearchView
+	searches   map[string]*SearchView
 }
 
 func (jw *JiraView) Walk(jc *Client, file string) (trees.File, error) {
@@ -984,7 +984,7 @@ func (jw *JiraView) Walk(jc *Client, file string) (trees.File, error) {
 	case "issues":
 		return NewJiraDir(file, 0555|qp.DMDIR, "jira", "jira", jc, &AllIssuesView{})
 	case "structure":
-message := `
+		message := `
 /
 	ctl
 	projects/

--- a/jira.go
+++ b/jira.go
@@ -36,7 +36,7 @@ func (wv *WorklogView) Walk(jc *Client, file string) (trees.File, error) {
 		t := time.Duration(w.TimeSpentSeconds) * time.Second
 		sf.SetContent([]byte(t.String() + "\n"))
 	case "started":
-		sf.SetContent([]byte(time.Time(w.Started).String() + "\n"))
+		sf.SetContent([]byte(time.Time(*w.Started).String() + "\n"))
 	default:
 		return nil, nil
 	}
@@ -891,7 +891,7 @@ func (jw *JiraView) Walk(jc *Client, file string) (trees.File, error) {
 					jc.user = args[0]
 					jc.pass = args[1]
 				}
-				return jc.login()
+				return nil
 			},
 			"set": func(args []string) error {
 				if len(args) != 2 {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/howeyc/gopass"
 	"github.com/joushou/qp"
@@ -20,8 +19,6 @@ var (
 	pkey        = flag.String("pkey", "", "private key file for OAuth")
 	pass        = flag.Bool("pass", false, "use password for authorization")
 	jiraURLStr  = flag.String("url", "", "jira URL")
-	loginInt    = flag.Int("loginint", 5, "login interval in minutes - 0 disables automatic relogin (password auth only)")
-	alwaysLogin = flag.Bool("alwayslogin", false, "log in on all requests (password auth only)")
 	maxlisting  = flag.Int("maxlisting", 100, "max directory listing length")
 )
 
@@ -36,7 +33,6 @@ func main() {
 
 	client := &Client{
 		Client:      &http.Client{},
-		alwaysLogin: *alwaysLogin,
 		usingOAuth:  *usingOAuth,
 		jiraURL:     jiraURL,
 		maxlisting:  *maxlisting,
@@ -57,16 +53,6 @@ func main() {
 
 			client.user = username
 			client.pass = string(password)
-			client.login()
-
-			if *loginInt > 0 {
-				go func() {
-					t := time.NewTicker(time.Duration(*loginInt) * time.Minute)
-					for range t.C {
-						client.login()
-					}
-				}()
-			}
 		} else {
 			fmt.Printf("Continuing without authentication.\n")
 		}

--- a/main.go
+++ b/main.go
@@ -13,13 +13,13 @@ import (
 )
 
 var (
-	address     = flag.String("address", "localhost:30000", "address to bind on")
-	usingOAuth  = flag.Bool("oauth", false, "use OAuth 1.0 for authorization")
-	ckey        = flag.String("ckey", "", "consumer key for OAuth")
-	pkey        = flag.String("pkey", "", "private key file for OAuth")
-	pass        = flag.Bool("pass", false, "use password for authorization")
-	jiraURLStr  = flag.String("url", "", "jira URL")
-	maxlisting  = flag.Int("maxlisting", 100, "max directory listing length")
+	address    = flag.String("address", "localhost:30000", "address to bind on")
+	usingOAuth = flag.Bool("oauth", false, "use OAuth 1.0 for authorization")
+	ckey       = flag.String("ckey", "", "consumer key for OAuth")
+	pkey       = flag.String("pkey", "", "private key file for OAuth")
+	pass       = flag.Bool("pass", false, "use password for authorization")
+	jiraURLStr = flag.String("url", "", "jira URL")
+	maxlisting = flag.Int("maxlisting", 100, "max directory listing length")
 )
 
 func main() {
@@ -32,10 +32,10 @@ func main() {
 	}
 
 	client := &Client{
-		Client:      &http.Client{},
-		usingOAuth:  *usingOAuth,
-		jiraURL:     jiraURL,
-		maxlisting:  *maxlisting,
+		Client:     &http.Client{},
+		usingOAuth: *usingOAuth,
+		jiraURL:    jiraURL,
+		maxlisting: *maxlisting,
 	}
 
 	switch {


### PR DESCRIPTION
@kennylevinsen , thank you for this repo! I'm now using jirafs to interface with the JIRA deployment at my day job. This pull request is to handle JIRA deprecation and removal of cookie-based authentication support, replacing it with basic authentication. I've updated the documentation accordingly. Unrelated, but I had to change time.Time(w.Started).String() to time.Time(*w.Started).String() in jira.go to even build building with the latest go-jira.